### PR TITLE
Fix ruby's blank mention

### DIFF
--- a/_posts/2015-06-10-how-to-write-guard-macros.md
+++ b/_posts/2015-06-10-how-to-write-guard-macros.md
@@ -11,7 +11,7 @@ Elixir, provided that the macro expands to expressions that are supported in
 guards natively.
 
 I used this to create an `is_blank` guard. Elixir doesn't come with a `blank?`
-function like Ruby does, so you have to do it manually. Blank values are `" "`,
+function, so you have to do it manually. Blank values are `" "`,
 `""`, and `nil`. To check `blank?` in Elixir, you can check if a given value is
 `in` this array of blank values.
 


### PR DESCRIPTION
Actually ruby doesn't, it's from rails. I don't think we need to compare lang with framework, so I deleted wrong statement.